### PR TITLE
upgrade the Ruby image version from 2.7.4 to 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Known version of ruby that is compatible with the current website configuration
-FROM ruby:2.7.4
+FROM ruby:3.0.0
 
 # Update gem so that it can still build 
 RUN gem update --system


### PR DESCRIPTION
I'm using a Mac M1 and when I tried to build the Dockerfile I got this error:

```bash
[+] Building 12.8s (7/15)
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 950B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/ruby:2.7.4                                                                                                                                                  1.0s
 => [auth] library/ruby:pull token for registry-1.docker.io                                                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                                              0.0s
 => => transferring context: 21.30kB                                                                                                                                                                           0.0s
 => CACHED [ 1/10] FROM docker.io/library/ruby:2.7.4@sha256:c4f29f28d297efcce62455a20d38383155a85eda9de38ed4635c2c5f3017df03                                                                                   0.0s
 => ERROR [ 2/10] RUN gem update --system                                                                                                                                                                     11.8s
------
 > [ 2/10] RUN gem update --system:
#6 11.72 ERROR:  Error installing rubygems-update:
#6 11.72 	There are no versions of rubygems-update (= 3.5.7) compatible with your Ruby & RubyGems
#6 11.72 	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.4.191.
#6 11.72 ERROR:  While executing gem ... (NoMethodError)
#6 11.72     undefined method `version' for nil:NilClass
#6 11.74 Updating rubygems-update
------
```

Based on the error, it is a version problem related to the Ruby image we are using. I upgraded the ruby version to `3.0.0` and it fixed the problem.